### PR TITLE
Enforce stock-perp-only candidate universe

### DIFF
--- a/config.py
+++ b/config.py
@@ -52,6 +52,9 @@ DEFAULT_INSURANCE_BUDGET_PCT = 1.50 # percent of budget
 HL_TRADFI_DEX = "xyz"
 HL_INFO_URL = "https://api.hyperliquid.xyz/info"
 
+# ── Stock-Only Mode ──────────────────────────────────────────────────────────
+STOCK_ONLY_MODE = True                # when True, only equity perps are eligible
+
 # ── Hedge Mapping ─────────────────────────────────────────────────────────────
 # xyz coin → equity/ETF hedge symbol for delta-neutral pairing.
 # Only coins with a mapping can receive allocation.
@@ -72,6 +75,13 @@ HEDGE_MAP = {
     "xyz:URANIUM": "URA", "xyz:NATGAS": "UNG", "xyz:CL": "USO",
     # Index → ETF proxies
     "xyz:XYZ100": "SPY",
+}
+
+# Non-stock coins — excluded when STOCK_ONLY_MODE is True.
+# These map to commodity ETFs or index ETFs, not individual equities.
+NON_STOCK_COINS: set[str] = {
+    "xyz:GOLD", "xyz:SILVER", "xyz:COPPER", "xyz:PLATINUM", "xyz:PALLADIUM",
+    "xyz:URANIUM", "xyz:NATGAS", "xyz:CL", "xyz:XYZ100",
 }
 
 # ── NASDAQ Symbol Directories ─────────────────────────────────────────────────

--- a/engine/scanner.py
+++ b/engine/scanner.py
@@ -265,6 +265,15 @@ def build_candidates(markets: list[dict], budget: float) -> ScanResult:
             })
             continue
 
+        # Stock-only filter
+        if config.STOCK_ONLY_MODE and coin in config.NON_STOCK_COINS:
+            rejected.append({
+                "coin": coin, "ticker": ticker,
+                "reason": "non-stock market excluded",
+                "forecast_apr": None, "score": None, "cap_final": None,
+            })
+            continue
+
         # Hard gate: maxLeverage >= 10
         max_lev = m.get("max_leverage") or 0
         if max_lev < config.MIN_MAX_LEVERAGE:


### PR DESCRIPTION
## Summary
- Adds `STOCK_ONLY_MODE = True` config toggle (default ON per user requirement)
- Defines `NON_STOCK_COINS` set: GOLD, SILVER, COPPER, PLATINUM, PALLADIUM, URANIUM, NATGAS, CL, XYZ100
- Scanner pre-filter rejects non-stock coins with explicit reason: `non-stock market excluded`
- All equity perps continue through full scoring/allocation path unchanged

## Test plan
- [ ] Run worker with `STOCK_ONLY_MODE = True` — verify CL, GOLD etc. appear in rejected with "non-stock market excluded"
- [ ] Run worker with `STOCK_ONLY_MODE = False` — verify commodity perps flow through normally
- [ ] Verify equity perps (TSLA, NVDA, etc.) unaffected in both modes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)