### PR TITLE
APR ranking transparency: instant vs EMA vs forecast + cutoff rank

### DIFF
--- a/db.py
+++ b/db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import threading
 from contextlib import contextmanager
@@ -48,8 +49,6 @@ def init_db():
 
 # ── Migrations ─────────────────────────────────────────────────────────────
 
-# Each migration is (table, column, column_def).
-# Applied idempotently: skipped if column already exists.
 _MIGRATIONS: list[tuple[str, str, str]] = [
     ("portfolio_targets", "run_status", "TEXT"),
     ("portfolio_targets", "deep_scan_cohort", "INTEGER DEFAULT 0"),
@@ -65,7 +64,7 @@ def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
 
 
 def _run_migrations():
-    """Apply pending ALTER TABLE ADD COLUMN migrations."""
+    """Apply pending ALTER TABLE ADD COLUMN migrations (idempotent)."""
     with get_db() as conn:
         cache: dict[str, set[str]] = {}
         applied = 0

--- a/engine/allocator.py
+++ b/engine/allocator.py
@@ -64,10 +64,13 @@ def build_portfolio(candidates: list, budget: float) -> Portfolio:
         5. Skip if alloc < min_ticket
         6. Accumulate until MAX_NAMES or budget exhausted
     """
-    emergency = max(config.EMERGENCY_FLOOR, config.EMERGENCY_PCT * budget)
-    deployable = budget - emergency - config.OPS_RESERVE
-    h_max = deployable / (1 + config.COLLATERAL_FRACTION)
-    min_ticket = max(config.MIN_TICKET_USD, config.MIN_TICKET_BUDGET_PCT * budget)
+    buckets = config.compute_budget_buckets(budget)
+    emergency = buckets["emergency"]
+    deployable = buckets["deployable"]
+    h_max = buckets["h_max"]
+    min_ticket = buckets["min_ticket"]
+    ops_reserve = buckets["ops_reserve"]
+    budget = buckets["budget"]
 
     if h_max < min_ticket:
         return _empty_portfolio(budget, emergency, deployable, h_max)
@@ -122,7 +125,7 @@ def build_portfolio(candidates: list, budget: float) -> Portfolio:
 
     perp_collateral = config.COLLATERAL_FRACTION * h_total
     coinbase_treasury = deployable - h_total - perp_collateral
-    coinbase_total = emergency + config.OPS_RESERVE + coinbase_treasury
+    coinbase_total = emergency + ops_reserve + coinbase_treasury
 
     # Portfolio net APR: weighted average of position net APRs
     # + Coinbase yield on treasury + emergency


### PR DESCRIPTION
## Summary
- **Scanner**: All rejection dicts now include `instant_apr` and `pre_rank`. `ScanResult` carries `deep_scan_cohort` count. Pre-filter adds sorting tie-breakers and `MAX_DEEP_SCAN_HARD=25`
- **Worker**: Persists `instant_apr`, `pre_rank` per rejected market. Saves `run_status` and `deep_scan_cohort` to portfolio targets
- **Config**: Adds `compute_budget_buckets()` for centralized budget math (used by allocator, scanner, UI)
- **DB**: New schema columns + idempotent migration layer for existing databases
- **UI**: Distinct empty states (never-run vs zero-positions), budget feasibility sidebar indicator, zero-allocation diagnostics card, enhanced rejected table with Instant APR/Pre-Rank/cohort context, fixes `import time` bug

## Test plan
- [ ] Fresh DB: `python worker.py` creates schema with all new columns
- [ ] Legacy DB: init_db migrates safely, no SQL errors
- [ ] UI shows "worker not run" when DB has no run_status
- [ ] UI shows diagnostics card when num_positions == 0
- [ ] Rejected table displays instant APR, pre-rank, and cohort caption
- [ ] Budget sidebar shows feasibility warning for small budgets
- [ ] Normal operation: portfolio table + rejected table both render with full data

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)