### PR TITLE
Fix SNDK mapping + coin normalization + rejection taxonomy

### DIFF
--- a/config.py
+++ b/config.py
@@ -68,8 +68,8 @@ HEDGE_MAP = {
     "xyz:LLY": "LLY", "xyz:META": "META", "xyz:MSFT": "MSFT",
     "xyz:MSTR": "MSTR", "xyz:MU": "MU", "xyz:NFLX": "NFLX",
     "xyz:NVDA": "NVDA", "xyz:ORCL": "ORCL", "xyz:PLTR": "PLTR",
-    "xyz:RIVN": "RIVN", "xyz:TSLA": "TSLA", "xyz:TSM": "TSM",
-    "xyz:URNM": "URNM",
+    "xyz:RIVN": "RIVN", "xyz:SNDK": "SNDK",
+    "xyz:TSLA": "TSLA", "xyz:TSM": "TSM", "xyz:URNM": "URNM",
     # Commodity → ETF proxies
     "xyz:GOLD": "GLD", "xyz:SILVER": "SLV", "xyz:COPPER": "CPER",
     "xyz:PLATINUM": "PPLT", "xyz:PALLADIUM": "PALL",
@@ -154,3 +154,15 @@ def compute_budget_buckets(budget: float) -> BudgetBuckets:
         "h_max": h_max,
         "min_ticket": min_ticket,
     }
+
+
+def normalize_coin(coin: str) -> str:
+    """Normalize a coin identifier: trim whitespace, uppercase the symbol part.
+
+    'xyz:sndk' -> 'xyz:SNDK', ' xyz:TSLA ' -> 'xyz:TSLA'
+    """
+    coin = coin.strip()
+    if ":" in coin:
+        prefix, symbol = coin.split(":", 1)
+        return f"{prefix.strip().lower()}:{symbol.strip().upper()}"
+    return coin.upper()

--- a/engine/scanner.py
+++ b/engine/scanner.py
@@ -253,7 +253,7 @@ def build_candidates(markets: list[dict], budget: float) -> ScanResult:
     # ── Phase 1: Fast pre-filter (no API calls) ────────────────────────────
     pre_filtered = []
     for m in markets:
-        coin = m["coin"]
+        coin = config.normalize_coin(m["coin"])
         ticker = m["ticker"]
 
         inst_funding_apr = round((m.get("funding_apr") or 0) * 100, 2)  # as %
@@ -263,7 +263,7 @@ def build_candidates(markets: list[dict], budget: float) -> ScanResult:
         if not hedge_symbol:
             rejected.append({
                 "coin": coin, "ticker": ticker,
-                "reason": "no hedge mapping",
+                "reason": "missing_hedge_mapping",
                 "instant_apr": inst_funding_apr,
                 "forecast_apr": None, "score": None, "cap_final": None, "pre_rank": None,
             })
@@ -273,7 +273,7 @@ def build_candidates(markets: list[dict], budget: float) -> ScanResult:
         if config.STOCK_ONLY_MODE and coin in config.NON_STOCK_COINS:
             rejected.append({
                 "coin": coin, "ticker": ticker,
-                "reason": "non-stock market excluded",
+                "reason": "non_stock_market_excluded",
                 "forecast_apr": None, "score": None, "cap_final": None,
             })
             continue
@@ -355,7 +355,8 @@ def build_candidates(markets: list[dict], budget: float) -> ScanResult:
         if not is_public_equity(hedge_symbol):
             rejected.append({
                 "coin": coin, "ticker": ticker,
-                "reason": f"hedge {hedge_symbol} not in public directories",
+                "reason": "not_in_public_directories",
+                "hedge_symbol": hedge_symbol,
                 "instant_apr": inst_apr, "pre_rank": ds_rank,
                 "forecast_apr": None, "score": None, "cap_final": None,
             })

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,86 @@
+"""Tests for hedge mapping, coin normalization, and rejection taxonomy."""
+
+import config
+
+
+def test_sndk_in_hedge_map():
+    """SNDK should be present in HEDGE_MAP."""
+    assert "xyz:SNDK" in config.HEDGE_MAP
+    assert config.HEDGE_MAP["xyz:SNDK"] == "SNDK"
+
+
+def test_normalize_coin_basic():
+    """Normalize should uppercase symbol and preserve prefix."""
+    assert config.normalize_coin("xyz:sndk") == "xyz:SNDK"
+    assert config.normalize_coin("xyz:TSLA") == "xyz:TSLA"
+
+
+def test_normalize_coin_whitespace():
+    """Normalize should strip whitespace."""
+    assert config.normalize_coin(" xyz:sndk ") == "xyz:SNDK"
+    assert config.normalize_coin("  xyz:TSLA  ") == "xyz:TSLA"
+
+
+def test_normalize_coin_mixed_case():
+    """Normalize should handle mixed case."""
+    assert config.normalize_coin("XYZ:tsla") == "xyz:TSLA"
+    assert config.normalize_coin("Xyz:Sndk") == "xyz:SNDK"
+
+
+def test_normalize_coin_no_prefix():
+    """Normalize should handle bare symbols."""
+    assert config.normalize_coin("tsla") == "TSLA"
+    assert config.normalize_coin(" sndk ") == "SNDK"
+
+
+def test_rejection_reason_codes():
+    """Rejection reasons should use structured taxonomy codes."""
+    from engine.scanner import build_candidates
+
+    # Create a fake market with no hedge mapping
+    markets = [{
+        "coin": "xyz:FAKECOIN",
+        "ticker": "FAKECOIN",
+        "mark_px": 100,
+        "mid_px": 100,
+        "funding_hourly": 0.001,
+        "funding_apr": 0.10,
+        "oi_base": 1000,
+        "oi_usd": 100000,
+        "volume_24h": 500000,
+        "max_leverage": 20,
+    }]
+    result = build_candidates(markets, 640_000)
+    fakecoin_rej = [r for r in result.rejected if r["coin"] == "xyz:FAKECOIN"]
+    assert len(fakecoin_rej) == 1
+    assert fakecoin_rej[0]["reason"] == "missing_hedge_mapping"
+
+
+def test_non_stock_rejection_code():
+    """Non-stock markets should use structured reason code."""
+    from engine.scanner import build_candidates
+
+    # GOLD is in HEDGE_MAP but in NON_STOCK_COINS
+    markets = [{
+        "coin": "xyz:GOLD",
+        "ticker": "GOLD",
+        "mark_px": 2000,
+        "mid_px": 2000,
+        "funding_hourly": 0.001,
+        "funding_apr": 0.10,
+        "oi_base": 1000,
+        "oi_usd": 100000,
+        "volume_24h": 500000,
+        "max_leverage": 20,
+    }]
+    result = build_candidates(markets, 640_000)
+    gold_rej = [r for r in result.rejected if r["coin"] == "xyz:GOLD"]
+    assert len(gold_rej) == 1
+    assert gold_rej[0]["reason"] == "non_stock_market_excluded"
+
+
+def test_normalized_coin_matches_hedge_map():
+    """Normalization should make coin lookup succeed for valid entries."""
+    raw = " xyz:sndk "
+    normalized = config.normalize_coin(raw)
+    assert normalized in config.HEDGE_MAP


### PR DESCRIPTION
## Summary
- Adds `xyz:SNDK -> SNDK` to HEDGE_MAP so SNDK is no longer falsely rejected
- Adds `normalize_coin()` — trims whitespace, lowercases prefix, uppercases symbol
- Replaces free-text rejection reasons with structured taxonomy codes:
  - `missing_hedge_mapping` (was "no hedge mapping")
  - `non_stock_market_excluded` (was "non-stock market excluded")
  - `not_in_public_directories` (was "hedge X not in public directories")

## Must-hold invariants
- `xyz:SNDK` resolves to `SNDK` in HEDGE_MAP and is never rejected for missing mapping
- `normalize_coin(" xyz:sndk ")` == `"xyz:SNDK"` — case and whitespace safe
- Stock-only filter (`STOCK_ONLY_MODE=True`) remains active for non-stock coins
- All rejection dicts use machine-readable `reason` codes (no free-text sentences)

## Scenario checklist
| Scenario | Expected |
|---|---|
| `xyz:SNDK` market in universe | Passes pre-filter, enters deep scan |
| `xyz:FAKECOIN` (no mapping) | Rejected with `missing_hedge_mapping` |
| `xyz:GOLD` (non-stock) | Rejected with `non_stock_market_excluded` |
| `" xyz:sndk "` normalized | Resolves to `xyz:SNDK`, matches HEDGE_MAP |

## Product-behavior test
`test_rejection_reason_codes` — feeds a fake market through `build_candidates()` end-to-end and asserts the rejection dict has reason code `missing_hedge_mapping` (not a free-text string).

## Test plan
- [x] 8 new tests in `tests/test_mapping.py` — all pass
- [x] Full suite: 41/41 pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)