### PR TITLE
Align UI diagnostics with structured rejection reason codes

### DIFF
--- a/tests/test_ui_reasons.py
+++ b/tests/test_ui_reasons.py
@@ -1,0 +1,69 @@
+"""Tests for UI rejection reason code handling."""
+
+# Import the reason label mapping directly — test that it covers all scanner codes
+import importlib
+import sys
+
+
+def _get_ui_reason_labels() -> dict:
+    """Import _REASON_LABELS from ui module without running Streamlit."""
+    # We can't import ui.py directly (it calls st.set_page_config at import).
+    # Instead, parse it and extract the dict.
+    import ast
+    with open("ui.py") as f:
+        source = f.read()
+    # Find the _REASON_LABELS assignment
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_REASON_LABELS":
+                    return ast.literal_eval(node.value)
+    raise RuntimeError("_REASON_LABELS not found in ui.py")
+
+
+def test_reason_labels_cover_structured_codes():
+    """All structured reason codes from scanner should have UI labels."""
+    labels = _get_ui_reason_labels()
+    required_codes = [
+        "missing_hedge_mapping",
+        "non_stock_market_excluded",
+        "not_in_public_directories",
+        "insufficient_history",
+        "negative funding forecast",
+        "negative/zero instantaneous funding",
+        "no funding history",
+    ]
+    for code in required_codes:
+        assert code in labels, f"Missing UI label for reason code: {code}"
+        assert isinstance(labels[code], str)
+        assert len(labels[code]) > 0
+
+
+def test_reason_labels_are_human_readable():
+    """Labels should not be raw codes (no underscores)."""
+    labels = _get_ui_reason_labels()
+    for code, label in labels.items():
+        assert "_" not in label, f"Label for '{code}' looks like a raw code: '{label}'"
+
+
+def test_no_legacy_substring_matching_in_diagnostics():
+    """UI diagnostics should use exact reason code matching, not substring contains."""
+    with open("ui.py") as f:
+        source = f.read()
+    # The old pattern was: "not in public directories" in r.get("reason", "")
+    # This should no longer appear
+    assert '"not in public directories" in' not in source, \
+        "UI still uses legacy substring matching for public directory rejections"
+    assert '"no hedge mapping" in' not in source, \
+        "UI still uses legacy substring matching for hedge mapping rejections"
+
+
+def test_diagnostics_uses_structured_lookup():
+    """UI diagnostics should use reason_counts dict with exact code keys."""
+    with open("ui.py") as f:
+        source = f.read()
+    # Should use .get("not_in_public_directories") not substring match
+    assert 'reason_counts.get("not_in_public_directories"' in source
+    assert 'reason_counts.get("insufficient_history"' in source
+    assert 'reason_counts.get("missing_hedge_mapping"' in source


### PR DESCRIPTION
## Summary
- Replaces legacy free-text substring matching in UI with exact reason code lookups
- Adds `_REASON_LABELS` dict mapping structured codes to human-readable labels (e.g. `not_in_public_directories` -> "Not in NASDAQ/NYSE")
- Zero-position diagnostics now counts by code: `not_in_public_directories`, `insufficient_history`, `missing_hedge_mapping`, `negative funding forecast`
- Fixes budget feasibility warning for waterfall mode (checks `h_max <= 0`, not old `h_max < min_ticket`)
- Simplifies `_min_actionable_budget()` to use `ALLOCATION_DUST_USD`
- **UI-only change** — no architecture/engine changes

## Must-hold invariants
- No reliance on legacy free-text substring matching (no `"not in public directories" in reason`)
- All 7 structured reason codes from scanner have UI label mappings
- Labels are human-readable (no underscores in displayed text)
- Stock-only filter remains active (`STOCK_ONLY_MODE=True`)
- Waterfall allocation unchanged — this is display-only

## Scenario checklist
| Scenario | Expected |
|---|---|
| Zero positions, 3 markets rejected `not_in_public_directories` | Diagnostics shows "**3 market(s)** rejected: hedge symbol not found in NASDAQ/NYSE" |
| Zero positions, 2 markets rejected `insufficient_history` | Diagnostics shows "**2 market(s)** rejected: insufficient funding history for EMA computation (need 21 8h epochs)" |
| Rejected table with `missing_hedge_mapping` code | Table shows "No hedge mapping" (not raw `missing_hedge_mapping`) |
| $2k budget | Warning shows "H_max = $0 (all capital goes to emergency reserve)" |
| Old DB rows with free-text reason | `_REASON_LABELS.get()` falls back to raw text — no crash |

## Product-behavior test
`test_no_legacy_substring_matching_in_diagnostics` — scans the actual `ui.py` source code and asserts that no legacy substring patterns like `"not in public directories" in` exist. This prevents regression to free-text matching if someone edits the diagnostics section.

## Test plan
- [x] 4 new tests in `tests/test_ui_reasons.py`
- [x] Full suite: 54/54 pass

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)