### PR TITLE
Fix emergency reserve: strictly proportional to budget

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,8 +8,8 @@ DEFAULT_BUDGET = 640_000
 
 # ── Risk Parameters ───────────────────────────────────────────────────────────
 COLLATERAL_FRACTION = 0.35          # 15% adverse + 10% maint + 10% buffer
-EMERGENCY_FLOOR = 50_000            # minimum emergency reserve
-EMERGENCY_PCT = 0.08                # 8% of budget; EMERGENCY = max(FLOOR, 0.08*B)
+EMERGENCY_FLOOR = 50_000            # DEPRECATED: not used in runtime math
+EMERGENCY_PCT = 0.08                # 8% of budget; EMERGENCY = 0.08 * B
 OPS_RESERVE = 5_000                 # kept inside Coinbase bucket
 
 # ── Multi-Asset Portfolio Limits ──────────────────────────────────────────────
@@ -137,8 +137,8 @@ def compute_budget_buckets(budget: float) -> BudgetBuckets:
     """Compute budget-derived portfolio buckets with safe lower bounds."""
     b = max(float(budget or 0), 0.0)
 
-    emergency_target = max(EMERGENCY_FLOOR, EMERGENCY_PCT * b)
-    emergency = min(b, emergency_target)
+    # Strictly proportional: E = clamp(EMERGENCY_PCT * B, 0, B)
+    emergency = min(b, EMERGENCY_PCT * b)
 
     remaining = max(0.0, b - emergency)
     ops_reserve = min(OPS_RESERVE, remaining)

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -5,22 +5,33 @@ from engine.allocator import build_portfolio
 
 
 def test_budget_buckets_standard():
-    """Standard budget produces correct reserves."""
+    """Standard budget produces correct reserves (proportional emergency)."""
     b = config.compute_budget_buckets(640_000)
     assert b["budget"] == 640_000
-    assert b["emergency"] == max(50_000, 0.08 * 640_000)  # 51200
+    assert b["emergency"] == 0.08 * 640_000  # 51200
     assert b["ops_reserve"] == 5_000
     assert b["deployable"] == 640_000 - b["emergency"] - b["ops_reserve"]
     assert b["h_max"] == b["deployable"] / (1 + config.COLLATERAL_FRACTION)
-    assert b["min_ticket"] == config.ALLOCATION_DUST_USD  # waterfall: dust only
+    assert b["min_ticket"] == config.ALLOCATION_DUST_USD
 
 
-def test_budget_buckets_small():
-    """Small budget: emergency takes floor of 50k."""
-    b = config.compute_budget_buckets(100_000)
-    assert b["emergency"] == 50_000  # floor dominates
-    assert b["deployable"] >= 0
-    assert b["h_max"] >= 0
+def test_budget_25k_proportional():
+    """$25k budget: emergency = 8% = $2,000, not absorbed by floor."""
+    b = config.compute_budget_buckets(25_000)
+    assert b["emergency"] == 2_000  # 0.08 * 25000
+    assert b["ops_reserve"] == 5_000
+    assert b["deployable"] == 18_000  # 25000 - 2000 - 5000
+    assert abs(b["h_max"] - 18_000 / (1 + config.COLLATERAL_FRACTION)) < 0.01
+    assert b["h_max"] > 0  # can allocate!
+
+
+def test_budget_2k_ops_absorbs():
+    """$2k budget: emergency=$160, ops absorbs rest, deployable=0."""
+    b = config.compute_budget_buckets(2_000)
+    assert b["emergency"] == 160  # 0.08 * 2000
+    assert b["ops_reserve"] == 1_840  # min(5000, 2000-160) = 1840
+    assert b["deployable"] == 0
+    assert b["h_max"] == 0
 
 
 def test_budget_buckets_zero():
@@ -39,8 +50,8 @@ def test_budget_buckets_negative():
 
 
 def test_budget_identity():
-    """E + OPS + DEPLOYABLE = B (budget identity)."""
-    for budget in [100_000, 300_000, 640_000, 1_000_000]:
+    """E + OPS + DEPLOYABLE = B (budget identity) for all budget sizes."""
+    for budget in [2_000, 10_000, 25_000, 100_000, 300_000, 640_000, 1_000_000]:
         b = config.compute_budget_buckets(budget)
         total = b["emergency"] + b["ops_reserve"] + b["deployable"]
         assert abs(total - b["budget"]) < 0.01, f"Identity failed for B={budget}"
@@ -48,7 +59,6 @@ def test_budget_identity():
 
 def test_low_budget_no_allocation():
     """Budget too small for min_ticket produces zero positions."""
-    # Budget so small that H_max < min_ticket
     portfolio = build_portfolio([], 10_000)
     assert portfolio.num_positions == 0
     assert portfolio.total_hedge_notional == 0
@@ -59,17 +69,24 @@ def test_dust_threshold():
     """min_ticket is now ALLOCATION_DUST_USD ($100), not the old hard floor."""
     b = config.compute_budget_buckets(640_000)
     assert b["min_ticket"] == config.ALLOCATION_DUST_USD
-    # Also verify for small budgets
     b_small = config.compute_budget_buckets(2_000)
     assert b_small["min_ticket"] == config.ALLOCATION_DUST_USD
 
 
-def test_emergency_floor_vs_pct():
-    """Emergency = max(50000, 0.08*B). Floor wins for B < 625k, pct wins above."""
-    # B = 500k: 0.08 * 500k = 40k < 50k, so emergency = 50k
-    b = config.compute_budget_buckets(500_000)
-    assert b["emergency"] == 50_000
+def test_emergency_strictly_proportional():
+    """Emergency is always 8% of budget — no floor, purely proportional."""
+    for budget in [10_000, 25_000, 100_000, 500_000, 700_000, 1_000_000]:
+        b = config.compute_budget_buckets(budget)
+        expected = config.EMERGENCY_PCT * budget
+        assert abs(b["emergency"] - expected) < 0.01, (
+            f"B={budget}: expected emergency={expected}, got {b['emergency']}"
+        )
 
-    # B = 700k: 0.08 * 700k = 56k > 50k, so emergency = 56k
-    b = config.compute_budget_buckets(700_000)
-    assert b["emergency"] == 56_000
+
+def test_emergency_floor_deprecated():
+    """EMERGENCY_FLOOR exists but is not used in runtime bucket math."""
+    assert hasattr(config, "EMERGENCY_FLOOR")
+    # Verify small budget does NOT use the floor
+    b = config.compute_budget_buckets(25_000)
+    assert b["emergency"] != config.EMERGENCY_FLOOR
+    assert b["emergency"] == 0.08 * 25_000


### PR DESCRIPTION
## Summary
- Remove `EMERGENCY_FLOOR` ($50k) from runtime budget math
- Emergency is now purely `0.08 * B` (proportional), not `max(50k, 0.08*B)`
- Small budgets ($25k, $10k) now get proportional emergency reserves instead of all capital being absorbed
- Update `_min_actionable_budget()` in UI to match the new formula
- `EMERGENCY_FLOOR` remains as deprecated config constant for backward compat

## Must-Hold Invariants
1. `emergency + ops_reserve + deployable == budget` (budget identity) for all B >= 0
2. `emergency == 0.08 * B` for all B > 0
3. `emergency == 0` when B == 0
4. `EMERGENCY_FLOOR` is never referenced in runtime math

## Scenario Checklist
| Budget | Emergency | OPS | Deployable | H_max |
|--------|-----------|-----|------------|-------|
| $25,000 | $2,000 | $5,000 | $18,000 | ~$13,333 |
| $2,000 | $160 | $1,840 | $0 | $0 |
| $640,000 | $51,200 | $5,000 | $583,800 | ~$432,444 |
| $0 | $0 | $0 | $0 | $0 |

## Product-Behavior Test
`test_budget_25k_proportional` — verifies that a $25k budget produces emergency=$2,000 (8%), ops=$5,000, deployable=$18,000, and positive H_max≈$13,333 (was previously $0 due to floor).

## Test Results
56 tests passing (10 budget + 6 waterfall + 40 others)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)