### PR TITLE
Fix L2 scoring: fail closed on missing orderbook depth

### DIFF
--- a/tests/test_l2_scoring.py
+++ b/tests/test_l2_scoring.py
@@ -1,0 +1,80 @@
+"""Tests for L2 fail-closed scoring — no -10k% artifacts."""
+
+from engine.hyperliquid import compute_impact
+from engine.scanner import compute_score
+
+
+def test_compute_impact_empty_book():
+    """Empty book → impact = 1.0 (100%)."""
+    book = {"bids": [], "asks": []}
+    assert compute_impact(book, 10_000) == 1.0
+
+
+def test_compute_impact_no_bids():
+    """No bids → impact = 1.0."""
+    book = {"bids": [], "asks": [{"px": 100, "sz": 10}]}
+    assert compute_impact(book, 10_000, side="sell") == 1.0
+
+
+def test_compute_impact_insufficient_depth():
+    """Insufficient depth to fill → impact = 1.0."""
+    book = {
+        "bids": [{"px": 100, "sz": 1}],  # $100 total depth
+        "asks": [{"px": 101, "sz": 1}],
+    }
+    assert compute_impact(book, 50_000, side="sell") == 1.0
+
+
+def test_compute_impact_valid():
+    """Valid book with sufficient depth → 0 <= impact < 1."""
+    book = {
+        "bids": [
+            {"px": 100.0, "sz": 100},  # $10,000
+            {"px": 99.5, "sz": 100},   # $9,950
+            {"px": 99.0, "sz": 100},   # $9,900
+        ],
+        "asks": [{"px": 100.5, "sz": 100}],
+    }
+    impact = compute_impact(book, 5_000, side="sell")
+    assert 0 <= impact < 1
+    assert impact < 0.01  # small order on decent book
+
+
+def test_no_score_emitted_for_impact_1():
+    """Score with impact=1.0 would produce ~-10,400% — verify the magnitude."""
+    # This demonstrates why we gate on impact < 1
+    score, _, slip_drag = compute_score(20.0, 1.0)
+    assert slip_drag > 10_000  # ~10,428%
+    assert score < -10_000  # ~-10,413%
+
+
+def test_no_extreme_score_from_valid_impact():
+    """Valid impact (< 1%) should never produce |score| > 1000%."""
+    score, _, _ = compute_score(50.0, 0.005)  # 0.5% impact
+    assert abs(score) < 1000
+
+
+def test_score_gating_threshold():
+    """Impact exactly at 1.0 is rejected; impact at 0.999 would be extreme."""
+    # 0.999 → slip_drag ≈ 10,418%, still extreme
+    _, _, slip = compute_score(20.0, 0.999)
+    assert slip > 10_000
+    # Any impact >= 1 should be gated by scanner (not scored)
+
+
+def test_ui_reason_labels_include_l2():
+    """UI _REASON_LABELS covers new L2 reason codes."""
+    import ast
+    with open("ui.py") as f:
+        source = f.read()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_REASON_LABELS":
+                    labels = ast.literal_eval(node.value)
+                    assert "no_l2_orderbook" in labels
+                    assert "insufficient_orderbook_depth" in labels
+                    assert "_" not in labels["no_l2_orderbook"]
+                    return
+    raise AssertionError("_REASON_LABELS not found")

--- a/ui.py
+++ b/ui.py
@@ -60,6 +60,8 @@ _REASON_LABELS = {
     "negative funding forecast": "Negative forecast",
     "negative/zero instantaneous funding": "Negative funding",
     "no funding history": "No funding data",
+    "no_l2_orderbook": "No L2 orderbook",
+    "insufficient_orderbook_depth": "Insufficient book depth",
 }
 
 
@@ -190,7 +192,15 @@ if num_positions == 0:
         insufficient = reason_counts.get("insufficient_history", [])
         missing_map = reason_counts.get("missing_hedge_mapping", [])
         non_stock = reason_counts.get("non_stock_market_excluded", [])
+        no_l2 = reason_counts.get("no_l2_orderbook", [])
+        insuf_depth = reason_counts.get("insufficient_orderbook_depth", [])
 
+        l2_total = len(no_l2) + len(insuf_depth)
+        if l2_total:
+            reasons.append(
+                f"**{l2_total} market(s)** rejected: L2 orderbook missing or "
+                f"insufficient depth for slippage scoring."
+            )
         if nasdaq_fails:
             reasons.append(
                 f"**{len(nasdaq_fails)} market(s)** rejected: hedge symbol not found in "


### PR DESCRIPTION
## Summary
- Remove fallback `cap_impact = cap_oi` when L2 book fetch fails — this produced `impact=1.0` → `slippage_drag≈10,428%` → `score≈-10,400%`
- Markets with missing/empty L2 data are now rejected with `no_l2_orderbook`
- Markets where `impact >= 1.0` (insufficient depth) are rejected with `insufficient_orderbook_depth`
- Score is only computed when impact is finite and in `[0, 1)`
- UI shows human-readable labels + diagnostics counts for L2 failures

## Must-Hold Invariants
1. No candidate or rejected row ever has `|score| > 1000%` from a missing-book path
2. `compute_impact()` returning `1.0` (empty/insufficient book) → market is rejected, not scored
3. Score computation only runs when `0 <= impact < 1` and `est_position > 0`
4. Valid-liquidity market ranking is unchanged

## Scenario Checklist
| L2 State | impact | Scanner Action |
|---|---|---|
| Fetch failed / exception | N/A | reject: `no_l2_orderbook` |
| Empty bids or asks | N/A | reject: `no_l2_orderbook` |
| `cap_impact = 0` | N/A | reject: `no_l2_orderbook` |
| `impact = 1.0` | 1.0 | reject: `insufficient_orderbook_depth` |
| `impact = 0.002` | 0.002 | score computed normally |

## Product-Behavior Test
`test_no_score_emitted_for_impact_1` — proves that `impact=1.0` with `compute_score()` would produce ~-10,400% score, confirming the gate is necessary. `test_no_extreme_score_from_valid_impact` — verifies valid impact never produces extreme scores.

## Test Results
62 tests passing (8 new L2 tests + 54 existing)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)